### PR TITLE
Converts the absolute links in the README file  into relative links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 A roadmap for learners in the Google Africa Developer Scholarship on Pluralsight
 
 
-[Mobile Web Specialist](https://github.com/mikeattara/GADS2020-Roadmap/blob/master/MWS.md)
+[Mobile Web Specialist](./MWS.md)
 
 
 
-[Cloud](https://github.com/mikeattara/GADS2020-Roadmap/blob/master/Cloud.md)
+[Cloud](./Cloud.md)
 
 
-[Android](https://github.com/mikeattara/GADS2020-Roadmap/blob/master/Android.md)
+[Android](./Android.md)


### PR DESCRIPTION
The links in the README file is still pointing to the repo in your account even after forking, so I converted them to relative links.

I hope the pull request will be accepted, thanks.